### PR TITLE
Fix work with stream in quic client

### DIFF
--- a/doqclient.go
+++ b/doqclient.go
@@ -218,7 +218,7 @@ func (s *quicConnection) getStream(endpoint string, log *logrus.Entry) (quic.Str
 
 	// If we can't get a stream then restart the connection and try again once
 	stream, err := s.EarlyConnection.OpenStream()
-	if netErr, ok := err.(net.Error); ok && (netErr.Timeout() || netErr.Temporary()) {
+	if err != nil {
 		log.WithError(err).Debug("temporary fail when trying to open stream, attempting new connection")
 		if err = quicRestart(s); err != nil {
 			log.WithFields(logrus.Fields{
@@ -229,7 +229,8 @@ func (s *quicConnection) getStream(endpoint string, log *logrus.Entry) (quic.Str
 		stream, err = s.EarlyConnection.OpenStream()
 		if err != nil {
 			log.WithError(err).Error("failed to open stream")
+			return nil, err
 		}
 	}
-	return stream, err
+	return stream, nil
 }


### PR DESCRIPTION
in the original project, the quic client did not work for me after 1 request, due to the fact that the error ("Application error 0x0 (remote)") did not meet the conditions. Why not recreate the stream at any error?